### PR TITLE
ci(github): gate Cloudflare Pages deploy to upstream

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'musi-lang/musi' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- restrict the Cloudflare Pages deploy job to musi-lang/musi on main
- prevent fork and non-upstream runs from reaching Wrangler without secrets
- keep website verification available without attempting deploys from review branches

## Test plan
- [x] workflow condition only affects deploy job selection
- [ ] verify upstream main still deploys with secrets present
- [ ] verify fork or non-upstream runs skip the deploy job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to ensure consistent release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->